### PR TITLE
docs(contributing): fix branch name, normalize .dart line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh text eol=lf
 *.desktop text eol=lf
+*.dart text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thanks for your interest in contributing! Here's how to get started.
 
 ## Pull Request Process
 
-1. Fork the repository and create a branch from `main`
+1. Fork the repository and create a branch from `master`
 2. Make your changes with clear, focused commits
 3. Ensure `flutter analyze` passes with no new issues
 4. Update documentation if adding new features


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` told contributors to branch from `main`, but the repo's default branch is `master`
- `.dart` files had no `eol` rule in `.gitattributes`, so a Windows checkout with `core.autocrlf=true` gets CRLF line endings, which makes `dart format lib/` (as step 3 of the Code Style section instructs) rewrite nearly every file on first run

## Test plan
- [x] Confirmed repo's default branch is `master` via `gh api`/`git remote show origin`
- [x] Verified `.dart` files check out with LF after the `.gitattributes` change
- [x] n/a — docs/config only, no app behavior changed